### PR TITLE
update show display related to association

### DIFF
--- a/app/controllers/belongs_controller.rb
+++ b/app/controllers/belongs_controller.rb
@@ -1,9 +1,9 @@
 class BelongsController < ApplicationController
   before_action :set_belong_new, only: [:index, :search]
-  before_action :set_belongs, only: [:index, :create]
   before_action :set_belong, only: [:show, :edit, :update]
 
   def index
+    @belongs = Belong.all
   end
 
   def create
@@ -11,6 +11,7 @@ class BelongsController < ApplicationController
     if @belong.save
       redirect_to belongs_path
     else
+      @belongs = Belong.all
       render "index"
     end
   end
@@ -39,10 +40,6 @@ class BelongsController < ApplicationController
 
   def set_belong_new
     @belong = Belong.new
-  end
-
-  def set_belongs
-    @belongs = Belong.all
   end
 
   def set_belong

--- a/app/controllers/belongs_controller.rb
+++ b/app/controllers/belongs_controller.rb
@@ -16,6 +16,7 @@ class BelongsController < ApplicationController
   end
 
   def show
+    @sales_ends = @belong.sales_ends
   end
 
   def edit

--- a/app/controllers/sales_ends_controller.rb
+++ b/app/controllers/sales_ends_controller.rb
@@ -17,6 +17,7 @@ class SalesEndsController < ApplicationController
   end
 
   def show
+    @customers = @sales_end.customers
   end
 
   def edit

--- a/app/controllers/sales_ends_controller.rb
+++ b/app/controllers/sales_ends_controller.rb
@@ -1,10 +1,10 @@
 class SalesEndsController < ApplicationController
   before_action :set_sales_end_new, only: [:index, :search]
-  before_action :set_sales_ends, only: [:index, :create]
   before_action :set_sales_end, only: [:show, :edit, :update]
-  before_action :set_belongs, only: [:index, :create, :edit, :update, :search]
+  before_action :set_belongs, only: [:index, :edit, :search]
 
   def index
+    @sales_ends = SalesEnd.all
   end
 
   def create
@@ -12,6 +12,8 @@ class SalesEndsController < ApplicationController
     if @sales_end.save
       redirect_to sales_end_path(@sales_end.id)
     else
+      set_belongs
+      @sales_ends = SalesEnd.all
       render "index"
     end
   end
@@ -27,6 +29,7 @@ class SalesEndsController < ApplicationController
     if @sales_end.update(params_sales_end)
       redirect_to sales_end_path(@sales_end.id)
     else
+      set_belongs
       render "edit"
     end
   end
@@ -42,10 +45,6 @@ class SalesEndsController < ApplicationController
 
   def set_sales_end_new
     @sales_end = SalesEnd.new
-  end
-
-  def set_sales_ends
-    @sales_ends = SalesEnd.all
   end
 
   def set_sales_end

--- a/app/views/belongs/show.html.slim
+++ b/app/views/belongs/show.html.slim
@@ -7,3 +7,17 @@
 			p.h5 住所
 			p = @belong.address
 			= link_to "編集", edit_belong_path(@belong.id), class: "btn btn-primary"
+
+			p.h5 所属メンバー
+			table.table
+				thead
+					tr
+						th 名前
+						th 役職
+						th 電話番号
+				tbody
+					- @sales_ends.each do |sales_end|
+						tr
+							td = link_to sales_end.name, sales_end_path(sales_end.id)
+							td = sales_end.post
+							td = sales_end.telephone_number

--- a/app/views/key_people/show.html.slim
+++ b/app/views/key_people/show.html.slim
@@ -9,3 +9,5 @@
 			p.h5 備考
 			p = @key_person.note
 			= link_to "編集", edit_key_person_path(@key_person.id), class: "btn btn-primary"
+			p.h5 所属
+			p = link_to @key_person.customer.name, customer_path(@key_person.customer.id)

--- a/app/views/sales_ends/show.html.slim
+++ b/app/views/sales_ends/show.html.slim
@@ -13,3 +13,12 @@
 			p.h5 備考
 			p = @sales_end.note
 			= link_to "編集", edit_sales_end_path(@sales_end.id), class: "btn btn-primary"
+			p.h5 担当顧客一覧
+			table.table
+				thead
+					tr
+						th 顧客名
+				tbody
+					- @customers.each do |customer|
+						tr
+							td = link_to customer.name, customer_path(customer.id)


### PR DESCRIPTION
### association追加により表示可能となった詳細画面の表示内容を追加した。 #11
対象ページは下記の通り。
- key_people#show
- belongs#show
- sales_ends#show

### 読み込み速度を考慮し、controller内の記述を変更した。
具体的には、DB変更時には読み込む必要がない情報をbefore_actionで読み込んでいたため
(失敗時の操作でrender先の表示で必要な要素)、失敗時の分岐のみの読み込みとなるよう変更した。