### PR TITLE
add activity MVC

### DIFF
--- a/app/assets/javascripts/activities.coffee
+++ b/app/assets/javascripts/activities.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/activities.scss
+++ b/app/assets/stylesheets/activities.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the activities controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -24,6 +24,8 @@ class ActivitiesController < ApplicationController
   end
 
   def search
+    @activities = Activity.search_name(params[:value])
+    render "index"
   end
 
   private

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,7 +1,9 @@
 class ActivitiesController < ApplicationController
+  before_action :set_activity_new, only: [:index, :search]
+  before_action :set_activity, only: [:edit, :update]
+
   def index
     @activities = Activity.all.order(:category)
-    @activity = Activity.new
   end
 
   def create
@@ -15,11 +17,9 @@ class ActivitiesController < ApplicationController
   end
 
   def edit
-    @activity = Activity.find(params[:id])
   end
 
   def update
-    @activity = Activity.find(params[:id])
     if @activity.update(params_activity)
       redirect_to activities_path
     else
@@ -29,11 +29,18 @@ class ActivitiesController < ApplicationController
 
   def search
     @activities = Activity.search_name(params[:value]).order(:category)
-    @activity = Activity.new
     render "index"
   end
 
   private
+
+  def set_activity_new
+    @activity = Activity.new
+  end
+
+  def set_activity
+    @activity = Activity.find(params[:id])
+  end
 
   def params_activity
     params.require(:activity).permit(:name, :category)

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,0 +1,16 @@
+class ActivitiesController < ApplicationController
+  def index
+  end
+
+  def create
+  end
+
+  def edit
+  end
+
+  def update
+  end
+
+  def search
+  end
+end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -11,9 +11,16 @@ class ActivitiesController < ApplicationController
   end
 
   def edit
+    @activity = Activity.find(params[:id])
   end
 
   def update
+    @activity = Activity.find(params[:id])
+    if @activity.update(params_activity)
+      redirect_to activities_path
+    else
+      render "edit"
+    end
   end
 
   def search

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,8 +1,13 @@
 class ActivitiesController < ApplicationController
   def index
+    @activities = Activity.all
+    @activity = Activity.new
   end
 
   def create
+    @activity = Activity.new(params_activity)
+    @activity.save
+    redirect_to activities_path
   end
 
   def edit
@@ -12,5 +17,12 @@ class ActivitiesController < ApplicationController
   end
 
   def search
+  end
+
+  private
+
+  def params_activity
+    params.require(:activity).permit(:name).
+      merge(category: params[:activity][:category].to_i)
   end
 end

--- a/app/controllers/activities_controller.rb
+++ b/app/controllers/activities_controller.rb
@@ -1,13 +1,17 @@
 class ActivitiesController < ApplicationController
   def index
-    @activities = Activity.all
+    @activities = Activity.all.order(:category)
     @activity = Activity.new
   end
 
   def create
     @activity = Activity.new(params_activity)
-    @activity.save
-    redirect_to activities_path
+    if @activity.save
+      redirect_to activities_path
+    else
+      @activities = Activity.all
+      render "index"
+    end
   end
 
   def edit
@@ -24,14 +28,14 @@ class ActivitiesController < ApplicationController
   end
 
   def search
-    @activities = Activity.search_name(params[:value])
+    @activities = Activity.search_name(params[:value]).order(:category)
+    @activity = Activity.new
     render "index"
   end
 
   private
 
   def params_activity
-    params.require(:activity).permit(:name).
-      merge(category: params[:activity][:category].to_i)
+    params.require(:activity).permit(:name, :category)
   end
 end

--- a/app/helpers/activities_helper.rb
+++ b/app/helpers/activities_helper.rb
@@ -1,0 +1,2 @@
+module ActivitiesHelper
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,0 +1,10 @@
+class Activity < ApplicationRecord
+  validates :name, :category, presence: true
+
+  enum category: {
+    プレゼン: 0,
+    定期訪問: 1,
+    打ち合せ: 2,
+    PR: 3,
+  }
+end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -7,4 +7,8 @@ class Activity < ApplicationRecord
     打ち合せ: 2,
     PR: 3,
   }
+
+  def self.search_name(value)
+    Activity.where("name LIKE ?", "%#{sanitize_sql_like(value)}%")
+  end
 end

--- a/app/views/activities/_form.html.slim
+++ b/app/views/activities/_form.html.slim
@@ -1,0 +1,11 @@
+= render "shared/error", obj: activity
+= form_with model: activity, local: true do |f|
+	.form-group
+		= f.label :category
+		= f.select :category,
+			options_for_select(Activity.categories.keys, activity.category), {},	class: "form-control category"
+	.form-group
+		= f.label :name
+		= f.text_field :name, class: "form-control name"
+	.form-group
+		= f.submit "新規登録", class: "btn btn-primary"

--- a/app/views/activities/edit.html.slim
+++ b/app/views/activities/edit.html.slim
@@ -1,0 +1,2 @@
+h1 Activities#edit
+p Find me in app/views/activities/edit.html.slim

--- a/app/views/activities/edit.html.slim
+++ b/app/views/activities/edit.html.slim
@@ -1,2 +1,16 @@
-h1 Activities#edit
-p Find me in app/views/activities/edit.html.slim
+.container
+	h2 活動種別編集
+	.row
+		.col-md-4
+			= form_with model: @activity, local: true do |f|
+				.form-group
+					= f.label :category
+					= f.select :category,
+						options_for_select(Activity.categories.keys, @activity.category),
+						{include_blank: "選択して下さい"},
+						class: "form-control category"
+				.form-group
+					= f.label :name
+					= f.text_field :name, class: "form-control name"
+				.form-group
+					= f.submit "変更保存", class: "btn btn-primary"

--- a/app/views/activities/edit.html.slim
+++ b/app/views/activities/edit.html.slim
@@ -2,14 +2,4 @@
 	h2 活動種別編集
 	.row
 		.col-md-4
-			= render "shared/error", obj: @activity
-			= form_with model: @activity, local: true do |f|
-				.form-group
-					= f.label :category
-					= f.select :category,
-						options_for_select(Activity.categories.keys, @activity.category),	{},	class: "form-control category"
-				.form-group
-					= f.label :name
-					= f.text_field :name, class: "form-control name"
-				.form-group
-					= f.submit "変更保存", class: "btn btn-primary"
+			= render "activities/form", activity: @activity, btn_name: "変更保存"

--- a/app/views/activities/edit.html.slim
+++ b/app/views/activities/edit.html.slim
@@ -2,13 +2,12 @@
 	h2 活動種別編集
 	.row
 		.col-md-4
+			= render "shared/error", obj: @activity
 			= form_with model: @activity, local: true do |f|
 				.form-group
 					= f.label :category
 					= f.select :category,
-						options_for_select(Activity.categories.keys, @activity.category),
-						{include_blank: "選択して下さい"},
-						class: "form-control category"
+						options_for_select(Activity.categories.keys, @activity.category),	{},	class: "form-control category"
 				.form-group
 					= f.label :name
 					= f.text_field :name, class: "form-control name"

--- a/app/views/activities/index.html.slim
+++ b/app/views/activities/index.html.slim
@@ -1,0 +1,2 @@
+h1 Activities#index
+p Find me in app/views/activities/index.html.slim

--- a/app/views/activities/index.html.slim
+++ b/app/views/activities/index.html.slim
@@ -2,6 +2,10 @@
 	h2 活動種別
 	.row
 		.col-md-8
+			.form-inline
+				= form_with url: activities_search_path, method: :post, local: true do |f|
+					= f.search_field :value, class: "form-control value"
+					= f.submit "検索", class: "btn btn-outline-success"
 			table.table
 				thead
 					tr

--- a/app/views/activities/index.html.slim
+++ b/app/views/activities/index.html.slim
@@ -19,13 +19,12 @@
 							td = activity.name
 							td = link_to "編集", edit_activity_path(activity.id), class: "btn btn-primary"
 		.col-md-4
+			= render "shared/error", obj: @activity
 			= form_with model: @activity, local: true do |f|
 				.form-group
 					= f.label :category
 					= f.select :category,
-						options_for_select(Activity.categories),
-						{include_blank: "選択して下さい"},
-						class: "form-control category"
+						options_for_select(Activity.categories.keys, @activity.category), {},	class: "form-control category"
 				.form-group
 					= f.label :name
 					= f.text_field :name, class: "form-control name"

--- a/app/views/activities/index.html.slim
+++ b/app/views/activities/index.html.slim
@@ -19,14 +19,4 @@
 							td = activity.name
 							td = link_to "編集", edit_activity_path(activity.id), class: "btn btn-primary"
 		.col-md-4
-			= render "shared/error", obj: @activity
-			= form_with model: @activity, local: true do |f|
-				.form-group
-					= f.label :category
-					= f.select :category,
-						options_for_select(Activity.categories.keys, @activity.category), {},	class: "form-control category"
-				.form-group
-					= f.label :name
-					= f.text_field :name, class: "form-control name"
-				.form-group
-					= f.submit "新規登録", class: "btn btn-primary"
+			= render "activities/form", activity: @activity, btn_name: "新規登録"

--- a/app/views/activities/index.html.slim
+++ b/app/views/activities/index.html.slim
@@ -1,2 +1,29 @@
-h1 Activities#index
-p Find me in app/views/activities/index.html.slim
+.container
+	h2 活動種別
+	.row
+		.col-md-8
+			table.table
+				thead
+					tr
+						th 活動分類
+						th 活動種別
+						th
+				tbody
+					- @activities.each do |activity|
+						tr
+							td = activity.category
+							td = activity.name
+							td = link_to "編集", edit_activity_path(activity.id), class: "btn btn-primary"
+		.col-md-4
+			= form_with model: @activity, local: true do |f|
+				.form-group
+					= f.label :category
+					= f.select :category,
+						options_for_select(Activity.categories),
+						{include_blank: "選択して下さい"},
+						class: "form-control category"
+				.form-group
+					= f.label :name
+					= f.text_field :name, class: "form-control name"
+				.form-group
+					= f.submit "新規登録", class: "btn btn-primary"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  resources :activities, only: [:create, :index, :edit, :update]
+  post 'activities/search'
   resources :customers, only: [:new, :create, :index, :show, :edit, :update]
   post 'customers/search'
   resources :key_people, only: [:create, :index, :show, :edit, :update]

--- a/db/migrate/20210509054356_create_activities.rb
+++ b/db/migrate/20210509054356_create_activities.rb
@@ -1,0 +1,14 @@
+class CreateActivities < ActiveRecord::Migration[5.2]
+  def change
+    create_table :activities do |t|
+      t.string :name
+      t.integer :category, default: 0
+
+      t.timestamps
+    end
+    change_column_null :activities, :name, false
+    change_column_null :activities, :category, false
+    add_index :activities, :name
+    add_index :activities, :category
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,25 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_07_225236) do
+ActiveRecord::Schema.define(version: 2021_05_09_054356) do
+
+  create_table "actions", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "category", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category"], name: "index_actions_on_category"
+    t.index ["name"], name: "index_actions_on_name"
+  end
+
+  create_table "activities", force: :cascade do |t|
+    t.string "name", null: false
+    t.integer "category", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category"], name: "index_activities_on_category"
+    t.index ["name"], name: "index_activities_on_name"
+  end
 
   create_table "belongs", force: :cascade do |t|
     t.string "name", null: false

--- a/test/controllers/activities_controller_test.rb
+++ b/test/controllers/activities_controller_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class ActivitiesControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get activities_index_url
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get activities_edit_url
+    assert_response :success
+  end
+end

--- a/test/fixtures/activities.yml
+++ b/test/fixtures/activities.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  category: 1
+
+two:
+  name: MyString
+  category: 1

--- a/test/models/activity_test.rb
+++ b/test/models/activity_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ActivityTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 活動種別MVCモデルの実装した。 #15
テーブル定義書及びアプリケーション詳細設計ではActionモデルと設計していたが、
恐らく名前が競合したために動作しない箇所が発生したため、**Activity**モデルに命名変更することとした。
これに伴い、活動内容モデル名をActivityDetailに変更する。
- ~~Action~~ → **Activity**モデルの生成
  - ~~actions~~ → **activities**テーブルの生成
  - モデルの編集
- controllerの生成
- routingの設定
- 各actionに対するcontrollerとviewの編集
  - index
  - create
  - edit
  - update
  - search