### PR TITLE
update views 1st for test deploy

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -19,3 +19,9 @@
 //= require activestorage
 //= require turbolinks
 //= require_tree .
+
+// bootstrapヘッダー固定時のページ開始位置の調節
+$(document).on('turbolinks:load', () => {
+  var height = $('.navbar').height();
+  $('body').css('padding-top',height);
+});

--- a/app/controllers/activity_details_controller.rb
+++ b/app/controllers/activity_details_controller.rb
@@ -1,19 +1,14 @@
 class ActivityDetailsController < ApplicationController
-  before_action :set_activity_detail_find, only: [:create, :update]
   before_action :set_activity_detail, only: [:update, :destroy]
 
   def create
-    if @activity_detail_find.nil?
-      @activity_detail = ActivityDetail.new(params_activity_detail)
-      @activity_detail.save
-    end
+    @activity_detail = ActivityDetail.new(params_activity_detail)
+    @activity_detail.save
     redirect_to visit_record_path(params[:activity_detail][:visit_record_id])
   end
 
   def update
-    if @activity_detail_find.nil?
-      @activity_detail.update(params_activity_detail)
-    end
+    @activity_detail.update(params_activity_detail)
     redirect_to visit_record_path(params[:activity_detail][:visit_record_id])
   end
 
@@ -26,10 +21,6 @@ class ActivityDetailsController < ApplicationController
 
   def set_activity_detail
     @activity_detail = ActivityDetail.find(params[:id])
-  end
-
-  def set_activity_detail_find
-    @activity_detail_find = ActivityDetail.find_by(params_activity_detail)
   end
 
   def params_activity_detail

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -9,6 +9,6 @@ module ApplicationHelper
   end
 
   def def_datetime(datetime)
-    datetime.strftime("%Y-%m-%d %H:%M")
+    datetime.nil? ? "なし" : datetime.strftime("%Y-%m-%d %H:%M")
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,4 +11,8 @@ module ApplicationHelper
   def def_datetime(datetime)
     datetime.nil? ? "なし" : datetime.strftime("%Y-%m-%d %H:%M")
   end
+
+  def btn_type(btn_name)
+    btn_name.include?("変更") ? "primary" : "success"
+  end
 end

--- a/app/models/activity.rb
+++ b/app/models/activity.rb
@@ -1,5 +1,6 @@
 class Activity < ApplicationRecord
   validates :name, :category, presence: true
+  validates :name, uniqueness: true
 
   has_many :activity_details
 

--- a/app/models/activity_detail.rb
+++ b/app/models/activity_detail.rb
@@ -1,5 +1,6 @@
 class ActivityDetail < ApplicationRecord
   validates :activity_id, :visit_record_id, presence: true
+  validates :activity_id, uniqueness: { scope: :visit_record_id }
 
   belongs_to :visit_record
   # TODO: 以下の方法で実装出来るか試す

--- a/app/models/belong.rb
+++ b/app/models/belong.rb
@@ -1,5 +1,6 @@
 class Belong < ApplicationRecord
   validates :name, presence: true
+  validates :name, uniqueness: true
 
   has_many :sales_ends
   has_many :visit_records

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -32,9 +32,6 @@ class Customer < ApplicationRecord
   end
 
   def latest_visit_record
-    VisitRecord.find(
-      VisitRecord.order(visit_datetime: :desc).
-      find_by(customer_id: self.id).id
-    )
+    visit_records.order(visit_datetime: :desc).last
   end
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,5 +1,6 @@
 class Customer < ApplicationRecord
   validates :name, presence: true
+  validates :name, :address, uniqueness: true
 
   belongs_to :sales_end
   belongs_to :key_person

--- a/app/models/key_person.rb
+++ b/app/models/key_person.rb
@@ -1,5 +1,6 @@
 class KeyPerson < ApplicationRecord
   validates :name, presence: true
+  validates :name, uniqueness: true
 
   has_one :customer
   has_many :visit_records

--- a/app/models/sales_end.rb
+++ b/app/models/sales_end.rb
@@ -1,5 +1,6 @@
 class SalesEnd < ApplicationRecord
   validates :name, presence: true
+  validates :name, uniqueness: true
 
   belongs_to :belong
   has_many :customers

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,4 +2,8 @@ class Task < ApplicationRecord
   validates :visit_record_id, :title, presence: true
 
   belongs_to :visit_record
+
+  def status
+    is_active? ? "実行中" : "完了"
+  end
 end

--- a/app/models/visit_record.rb
+++ b/app/models/visit_record.rb
@@ -31,6 +31,6 @@ class VisitRecord < ApplicationRecord
   end
 
   def find_active_tasks
-    Task.where(visit_record_id: self.id, is_active: true)
+    tasks.where(is_active: true)
   end
 end

--- a/app/models/visit_record.rb
+++ b/app/models/visit_record.rb
@@ -5,7 +5,7 @@ class VisitRecord < ApplicationRecord
   belongs_to :key_person
   belongs_to :belong
   belongs_to :sales_end
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
   has_many :activity_details, dependent: :destroy
   # TODO: 以下の方法で実装出来るか試す
   # , inverse_of: :visit_record

--- a/app/views/activities/_form.html.slim
+++ b/app/views/activities/_form.html.slim
@@ -1,11 +1,13 @@
 = render "shared/error", obj: activity
 = form_with model: activity, local: true do |f|
 	.form-group
-		= f.label :category
+		= f.label :category, "カテゴリー"
 		= f.select :category,
-			options_for_select(Activity.categories.keys, activity.category), {},	class: "form-control category"
+			options_for_select(Activity.categories.keys, activity.category), {}, class: "form-control category"
+
 	.form-group
-		= f.label :name
+		= f.label :name, "活動種別名"
 		= f.text_field :name, class: "form-control name"
+
 	.form-group
-		= f.submit "新規登録", class: "btn btn-primary"
+		= f.submit btn_name, class: "btn btn-#{btn_type(btn_name)}"

--- a/app/views/activity_details/_form.html.slim
+++ b/app/views/activity_details/_form.html.slim
@@ -1,11 +1,9 @@
 = form_with model: [visit_record, activity_detail], local: true do |f|
 	= f.hidden_field :visit_record_id, value: visit_record.id
 
-	- type = btn_name == "変更" ? "primary" : "success"
-
 	.form-inline
 		= f.collection_select :activity_id, activities, :id, :name, {prompt: "選択して下さい"}, class: "form-control activity_id"
-		= f.submit btn_name, class: "btn btn-#{type}"
+		= f.submit btn_name, class: "btn btn-#{btn_type(btn_name)}"
 		= link_to "削除",
 			visit_record_activity_detail_path(visit_record.id, activity_detail.id),
 			method: :delete,

--- a/app/views/activity_details/_form.html.slim
+++ b/app/views/activity_details/_form.html.slim
@@ -1,0 +1,12 @@
+= form_with model: [visit_record, activity_detail], local: true do |f|
+	= f.hidden_field :visit_record_id, value: visit_record.id
+
+	- type = btn_name == "変更" ? "primary" : "success"
+
+	.form-inline
+		= f.collection_select :activity_id, activities, :id, :name, {prompt: "選択して下さい"}, class: "form-control activity_id"
+		= f.submit btn_name, class: "btn btn-#{type}"
+		= link_to "削除",
+			visit_record_activity_detail_path(visit_record.id, activity_detail.id),
+			method: :delete,
+			class: "btn btn-danger" if btn_name == "変更"

--- a/app/views/belongs/_form.html.slim
+++ b/app/views/belongs/_form.html.slim
@@ -1,10 +1,12 @@
 = render "shared/error", obj: belong
 = form_with model: belong, local: true do |f|
   .form-group
-    = f.label :name
+    = f.label :name, "所属名"
     = f.text_field :name, class: "form-control name"
+
   .form-group
-    = f.label :address
+    = f.label :address, "住所"
     = f.text_field :address, class: "form-control address"
+
   .form-group
-    = f.submit btn_name, class: "btn btn-primary"
+    = f.submit btn_name, class: "btn btn-#{btn_type(btn_name)}"

--- a/app/views/customers/edit.html.slim
+++ b/app/views/customers/edit.html.slim
@@ -5,19 +5,29 @@
 		  = render "shared/error", obj: @customer
 		  = form_with model: @customer, local: true do |f|
 		    .form-group
-		      = f.label :name
+		      = f.label :name, "顧客名"
 		      = f.text_field :name, class: "form-control name"
+
 		    .form-group
-		      = f.label :address
+		      = f.label :address, "住所"
 		      = f.text_field :address, class: "form-control address"
+
 		    .form-group
-		      = f.label :key_person_id
-		      = f.collection_select :key_person_id, @key_people, :id, :name, {prompt: "選択して下さい"}, class: "form-control key_person_id"
+		      = f.label :key_person_id, "窓口担当者"
+		      = f.collection_select :key_person_id,
+		      	@key_people, :id, :name,
+		      	{prompt: "選択して下さい"},
+		      	class: "form-control key_person_id"
+
 		    .form-group
-		      = f.label :sales_end_id
-		      = f.collection_select :sales_end_id, @sales_ends, :id, :name, {prompt: "選択して下さい"}, class: "form-control sales_end_id"
+		      = f.label :sales_end_id, "営業担当者"
+		      = f.collection_select :sales_end_id,
+		      	@sales_ends, :id, :name,
+		      	{prompt: "選択して下さい"},
+		      	class: "form-control sales_end_id"
+
 		    .form-group
-					= f.label :system
+					= f.label :system, "導入システム"
 					= f.select :system,
 						options_for_select(Customer.systems.keys, @customer.system),
 						{},

--- a/app/views/customers/new.html.slim
+++ b/app/views/customers/new.html.slim
@@ -17,7 +17,12 @@
 		      .form-group.col
 		        = f.radio_button :key_person, :id, checked: "checked"
 		        = f.label :key_person_id, "登録済より選択"
-		        = f.collection_select :key_person_id, @key_people, :id, :name, {prompt: "選択して下さい"}, autofocus: true, class: "form-control key_person_id"
+		        = f.collection_select :key_person_id,
+		          @key_people, :id, :name,
+		          {prompt: "選択して下さい"},
+		          autofocus: true,
+		          class: "form-control key_person_id"
+
 		      .form-group.col
 		        = f.radio_button :key_person, :name
 		        = f.label :key_person_name, "新規登録"
@@ -28,7 +33,12 @@
 		      .form-group.col
 		        = f.radio_button :sales_end, :id, checked: "checked"
 		        = f.label :sales_end_id, "登録済より選択"
-		        = f.collection_select :sales_end_id, @sales_ends, :id, :name, {prompt: "選択して下さい"}, autofocus: true, class: "form-control sales_end_id"
+		        = f.collection_select :sales_end_id,
+		          @sales_ends, :id, :name,
+		          {prompt: "選択して下さい"},
+		          autofocus: true,
+		          class: "form-control sales_end_id"
+
 		      .form-group.col
 		        = f.radio_button :sales_end, :name
 		        = f.label :sales_end_name, "新規登録"
@@ -41,14 +51,23 @@
 		        .form-group.col
 		          = f.radio_button :belong, :id, checked: "checked"
 		          = f.label :belong_id, "登録済より選択"
-		          = f.collection_select :belong_id, @belongs, :id, :name, {prompt: "選択して下さい"}, autofocus: true, class: "form-control belong_id"
+		          = f.collection_select :belong_id,
+		            @belongs, :id, :name,
+		            {prompt: "選択して下さい"},
+		            autofocus: true,
+		            class: "form-control belong_id"
+
 		        .form-group.col
 		          = f.radio_button :belong, :name
 		          = f.label :belong_name, "新規登録"
 		          = f.text_field :belong_name, class: "form-control belong_name"
-		    .form-group
-		      = f.label :system
-		      = f.select :system, options_for_select(Customer.systems.keys, @customer.system), {}, class: "form-control system"
 
 		    .form-group
-		      = f.submit "新規登録", class: "btn btn-primary"
+		      = f.label :system, "導入システム"
+		      = f.select :system,
+		        options_for_select(Customer.systems.keys, @customer.system),
+		        {},
+		        class: "form-control system"
+
+		    .form-group
+		      = f.submit "新規登録", class: "btn btn-success"

--- a/app/views/homes/map.html.erb
+++ b/app/views/homes/map.html.erb
@@ -51,8 +51,8 @@
         	'<td><%= link_to def_datetime(visit_record.visit_datetime), visit_record_path(visit_record.id) %>' +
         	'</td></tr><tr><th>窓口担当者:</th><td><%= link_to visit_record.key_person.name, key_person_path(visit_record.key_person_id) %>' +
         	'</td></tr><tr><th>営業担当者:</th><td><%= link_to visit_record.sales_end.name, sales_end_path(visit_record.sales_end_id) %></td></tr>' +
-				  '<tr><th>次回訪問予定日:</th><td><%= visit_record.next_datetime.nil? ? "なし" : def_datetime(visit_record.next_datetime) %>' +
-				  '</td></tr><tr><th>タスク:</th><td><%= "なし" if visit_record.find_active_tasks.blank? %><% visit_record.find_active_tasks.each do |active_task| %>' +
+				  '<tr><th>次回訪問予定日:</th><td><%= def_datetime(visit_record.next_datetime) %></td></tr><tr><th>タスク:</th><td>' +
+				  '<%= "なし" if visit_record.find_active_tasks.blank? %><% visit_record.find_active_tasks.each do |active_task| %>' +
 					'<%= link_to active_task.title, visit_record_task_path(visit_record.id, active_task.id) %><br><% end %></td></tr></table>',
       });
 

--- a/app/views/homes/map.html.erb
+++ b/app/views/homes/map.html.erb
@@ -1,7 +1,7 @@
 <div class="container">
 	<div class="row">
 		<div class="col">
-			<!--<div id="mapTop" style="height: 500px;"></div>-->
+			<div id="mapTop" style="height: 500px;"></div>
 		</div>
 	</div>
 </div>
@@ -20,7 +20,7 @@
     		lat: <%= sprintf("%.6f", Customer.average(:latitude)) %>,
     		lng: <%= sprintf("%.6f", Customer.average(:longitude)) %>
     	},
-    	zoom: 15,
+    	zoom: 10,
     });
 
 		let i = 0;
@@ -33,7 +33,11 @@
       });
 
 		// 	マーカーの選択
-			<% icon_color = visit_record.find_active_tasks.blank? ? "blue" : "red" %>
+		  <% icon_color = if visit_record.nil?
+		                    "blue"
+		                  else
+		                    visit_record.find_active_tasks.blank? ? "blue" : "red"
+		                  end %>
 			<% icon_style = customer.system.include?("systemA") ? "-pushpin" : "-dot" %>
 			icon_url = "https://maps.google.com/mapfiles/ms/micons/" + "<%= icon_color %>" + "<%= icon_style %>" + ".png"
 
@@ -47,13 +51,13 @@
       // 内容が整備しづらいため、要対応
       infoWindow[i] = new google.maps.InfoWindow({
         content:
-        	'<table><tr><th>顧客名:</th><td><%= customer.name %></td></tr><tr><th>前回訪問日:</th>' +
+        	'<table><tr><th>顧客名:</th><td><%= customer.name %></td></tr><% unless visit_record.nil? %><tr><th>前回訪問日:</th>' +
         	'<td><%= link_to def_datetime(visit_record.visit_datetime), visit_record_path(visit_record.id) %>' +
         	'</td></tr><tr><th>窓口担当者:</th><td><%= link_to visit_record.key_person.name, key_person_path(visit_record.key_person_id) %>' +
         	'</td></tr><tr><th>営業担当者:</th><td><%= link_to visit_record.sales_end.name, sales_end_path(visit_record.sales_end_id) %></td></tr>' +
 				  '<tr><th>次回訪問予定日:</th><td><%= def_datetime(visit_record.next_datetime) %></td></tr><tr><th>タスク:</th><td>' +
 				  '<%= "なし" if visit_record.find_active_tasks.blank? %><% visit_record.find_active_tasks.each do |active_task| %>' +
-					'<%= link_to active_task.title, visit_record_task_path(visit_record.id, active_task.id) %><br><% end %></td></tr></table>',
+					'<%= link_to active_task.title, visit_record_task_path(visit_record.id, active_task.id) %><br><% end %></td></tr><% end %></table>',
       });
 
       markerEvent(i);

--- a/app/views/key_people/_form.html.slim
+++ b/app/views/key_people/_form.html.slim
@@ -1,13 +1,16 @@
 = render "shared/error", obj: key_person
 = form_with model: key_person, local: true do |f|
   .form-group
-    = f.label :name
+    = f.label :name, "営業担当者名"
     = f.text_field :name, class: "form-control name"
+
   .form-group
-    = f.label :career
+    = f.label :career, "経歴"
     = f.text_area :career, class: "form-control career"
+
   .form-group
-  	= f.label :note
+  	= f.label :note, "備考"
   	= f.text_area :note, class: "form-control note"
+
   .form-group
-    = f.submit btn_name, class: "btn btn-primary"
+    = f.submit btn_name, class: "btn btn-#{btn_type(btn_name)}"

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -14,5 +14,5 @@
 						tr
 							td = link_to task.title, visit_record_task_path(task.visit_record_id, task.id)
 							td.text-truncate = task.content
-							td = task.deadline.strftime("%Y-%m-%d %H:%M")
-							td = link_to task.visit_record.visit_datetime.strftime("%Y-%m-%d %H:%M"), visit_record_path(task.visit_record_id)
+							td = def_datetime(task.deadline)
+							td = link_to def_datetime(task.visit_record.visit_datetime), visit_record_path(task.visit_record_id)

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -9,10 +9,7 @@
 			p.h5 期限
 			p = def_datetime(@task.deadline)
 			p.h5 タスクの状態
-			- if @task.is_active?
-					p 実行中
-			- else
-					p 完了
+			p = @task.status
 			= link_to "編集", edit_visit_record_task_path(@task.visit_record_id, @task.id), class: "btn btn-primary"
 			p.h4 訪問記録の詳細
 			= render "visit_records/show", visit_record: @task.visit_record

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -7,7 +7,7 @@
 			p.h5 内容
 			p = @task.content
 			p.h5 期限
-			p = @task.deadline.strftime("%Y-%m-%d %H:%M")
+			p = def_datetime(@task.deadline)
 			p.h5 タスクの状態
 			- if @task.is_active?
 					p 実行中

--- a/app/views/visit_records/_show.html.slim
+++ b/app/views/visit_records/_show.html.slim
@@ -14,17 +14,11 @@ p = link_to_unless_current def_datetime(visit_record.visit_datetime), visit_reco
 	.col
 		p.h5 営業担当者
 		p = link_to visit_record.sales_end.name, sales_end_path(visit_record.sales_end.id)
+.row
+	.col
 		p.h5 次回訪問日時
-		- if visit_record.next_datetime.present?
-			p = def_datetime(visit_record.next_datetime)
-		- else
-			p なし
+		p = def_datetime(visit_record.next_datetime)
 		p.h5 備考
 		p = visit_record.note
 		p.h5 ランク
 		p = visit_record.rank
-		p.h5 活動内容
-		p
-			- visit_record.activity_details.each do |activity_detail|
-				= activity_detail.activity.name
-				<br>

--- a/app/views/visit_records/index.html.slim
+++ b/app/views/visit_records/index.html.slim
@@ -3,7 +3,7 @@
 	.row
 		.col-md-8
 			.d-flex.justify-content-end
-				= link_to "新規登録", new_visit_record_path, class: "btn btn-primary"
+				= link_to "新規登録", new_visit_record_path, class: "btn btn-success"
 			table.table
 				thead
 					tr

--- a/app/views/visit_records/show.html.slim
+++ b/app/views/visit_records/show.html.slim
@@ -21,22 +21,21 @@
 				btn_name: "活動種別 追加"
 
 	.row
-		.col-md-4
+		.col-md-6
 			p.h4 タスク
 			- if @visit_record.tasks.present?
 				table.table
 					thead
 						tr
 							th タイトル
+							th 期限
 							th タスクの状態
 					tbody
 						- @visit_record.tasks.each do |task|
 							tr
 								td = link_to task.title, visit_record_task_path(@visit_record.id, task.id)
-								td
-									- if task.is_active?
-										p 実行中
-									- else
-										p 完了
+								td = def_datetime(task.deadline)
+								td = task.status
+
 			.form-group
 				= link_to "タスク追加", new_visit_record_task_path(@visit_record.id), class: "btn btn-success	"

--- a/app/views/visit_records/show.html.slim
+++ b/app/views/visit_records/show.html.slim
@@ -6,26 +6,24 @@
 			.form-group
 				= link_to "編集", edit_visit_record_path(@visit_record.id), class: "btn btn-primary"
 
-			= form_with model: [@visit_record, @activity_detail], local: true do |f|
-				= f.hidden_field :visit_record_id, value: @visit_record.id
-				.form-inline
-					= f.collection_select :activity_id, @activities, :id, :name, {prompt: "選択して下さい"}, class: "form-control activity_id"
-					= f.submit "新規登録", class: "btn btn-primary"
-
+			p.h4 活動内容
 			- @visit_record.activity_details.each do |activity_detail|
-				= form_with model: [@visit_record, activity_detail], local: true do |f|
-					= f.hidden_field :visit_record_id, value: @visit_record.id
-					.form-inline
-						= f.collection_select :activity_id, @activities, :id, :name, {prompt: "選択して下さい"}, class: "form-control activity_id"
-						= f.submit "変更", class: "btn btn-primary"
-						= link_to "削除", visit_record_activity_detail_path(@visit_record.id, activity_detail.id), method: :delete, class: "btn btn-danger"
+				= render "activity_details/form",
+					visit_record: @visit_record,
+					activity_detail: activity_detail,
+					activities: @activities,
+					btn_name: "変更"
 
-			.form-group
-				= link_to "タスク追加", new_visit_record_task_path(@visit_record.id), class: "btn btn-success	"
-	- if @visit_record.tasks.present?
-		.row
-			.col-md-4
-				p.h4 タスク一覧
+			= render "activity_details/form",
+				visit_record: @visit_record,
+				activity_detail: @activity_detail,
+				activities: @activities,
+				btn_name: "活動種別 追加"
+
+	.row
+		.col-md-4
+			p.h4 タスク
+			- if @visit_record.tasks.present?
 				table.table
 					thead
 						tr
@@ -40,3 +38,5 @@
 										p 実行中
 									- else
 										p 完了
+			.form-group
+				= link_to "タスク追加", new_visit_record_task_path(@visit_record.id), class: "btn btn-success	"

--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -1,0 +1,23 @@
+Geocoder.configure(
+  # Geocoding options
+  # timeout: 3,                 # geocoding service timeout (secs)
+  # lookup: :nominatim,         # name of geocoding service (symbol)
+  lookup: :google,
+  # ip_lookup: :ipinfo_io,      # name of IP address geocoding service (symbol)
+  # language: :en,              # ISO-639 language code
+  # use_https: false,           # use HTTPS for lookup requests? (if supported)
+  # http_proxy: nil,            # HTTP proxy server (user:pass@host:port)
+  # https_proxy: nil,           # HTTPS proxy server (user:pass@host:port)
+  api_key: ENV['GOOGLE_MAP_API'],               # API key for geocoding service
+  # cache: nil,                 # cache object (must respond to #[], #[]=, and #del)
+  # cache_prefix: 'geocoder:',  # prefix (string) to use for all cache keys
+
+  # Exceptions that should not be rescued by default
+  # (if you want to implement custom error handling);
+  # supports SocketError and Timeout::Error
+  # always_raise: [],
+
+  # Calculation options
+  # units: :mi,                 # :km for kilometers or :mi for miles
+  # distances: :linear          # :spherical or :linear
+)

--- a/db/migrate/20210505055212_create_belongs.rb
+++ b/db/migrate/20210505055212_create_belongs.rb
@@ -7,6 +7,6 @@ class CreateBelongs < ActiveRecord::Migration[5.2]
       t.timestamps
     end
     change_column_null :belongs, :name, false
-    add_index :belongs, :name
+    add_index :belongs, :name, unique: true
   end
 end

--- a/db/migrate/20210505142537_create_sales_ends.rb
+++ b/db/migrate/20210505142537_create_sales_ends.rb
@@ -10,6 +10,6 @@ class CreateSalesEnds < ActiveRecord::Migration[5.2]
       t.timestamps
     end
     change_column_null :sales_ends, :name, false
-    add_index :sales_ends, :name
+    add_index :sales_ends, :name, unique: true
   end
 end

--- a/db/migrate/20210506145137_create_key_people.rb
+++ b/db/migrate/20210506145137_create_key_people.rb
@@ -8,6 +8,6 @@ class CreateKeyPeople < ActiveRecord::Migration[5.2]
       t.timestamps
     end
     change_column_null :key_people, :name, false
-    add_index :key_people, :name
+    add_index :key_people, :name, unique: true
   end
 end

--- a/db/migrate/20210507225236_create_customers.rb
+++ b/db/migrate/20210507225236_create_customers.rb
@@ -12,7 +12,7 @@ class CreateCustomers < ActiveRecord::Migration[5.2]
       t.timestamps
     end
     change_column_null :customers, :name, false
-    add_index :customers, :name
-    add_index :customers, :address
+    add_index :customers, :name, unique: true
+    add_index :customers, :address, unique: true
   end
 end

--- a/db/migrate/20210509054356_create_activities.rb
+++ b/db/migrate/20210509054356_create_activities.rb
@@ -8,7 +8,7 @@ class CreateActivities < ActiveRecord::Migration[5.2]
     end
     change_column_null :activities, :name, false
     change_column_null :activities, :category, false
-    add_index :activities, :name
+    add_index :activities, :name, unique: true
     add_index :activities, :category
   end
 end

--- a/db/migrate/20210509104755_create_activity_details.rb
+++ b/db/migrate/20210509104755_create_activity_details.rb
@@ -8,5 +8,6 @@ class CreateActivityDetails < ActiveRecord::Migration[5.2]
     end
     change_column_null :activity_details, :visit_record_id, false
     change_column_null :activity_details, :activity_id, false
+    add_index :activity_details, [:visit_record_id, :activity_id], unique: true 
   end
 end

--- a/db/migrate/20210517063327_devise_create_users.rb
+++ b/db/migrate/20210517063327_devise_create_users.rb
@@ -8,8 +8,8 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       t.string :encrypted_password, null: false, default: ""
 
       ## Recoverable
-      t.string   :reset_password_token
-      t.datetime :reset_password_sent_at
+      # t.string   :reset_password_token
+      # t.datetime :reset_password_sent_at
 
       ## Rememberable
       t.datetime :remember_created_at
@@ -36,8 +36,8 @@ class DeviseCreateUsers < ActiveRecord::Migration[5.2]
       t.timestamps null: false
     end
 
-    add_index :users, :email,                unique: true
-    add_index :users, :reset_password_token, unique: true
+    # add_index :users, :email,                unique: true
+    # add_index :users, :reset_password_token, unique: true
     # add_index :users, :confirmation_token,   unique: true
     # add_index :users, :unlock_token,         unique: true
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -68,7 +68,7 @@ ActiveRecord::Schema.define(version: 2021_05_17_063327) do
     t.text "note"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_sales_ends_on_name"
+    t.index ["name"], name: "index_sales_ends_on_name", unique: true
   end
 
   create_table "tasks", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -18,7 +18,7 @@ ActiveRecord::Schema.define(version: 2021_05_17_063327) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["category"], name: "index_activities_on_category"
-    t.index ["name"], name: "index_activities_on_name"
+    t.index ["name"], name: "index_activities_on_name", unique: true
   end
 
   create_table "activity_details", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -34,7 +34,7 @@ ActiveRecord::Schema.define(version: 2021_05_17_063327) do
     t.string "address"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_belongs_on_name"
+    t.index ["name"], name: "index_belongs_on_name", unique: true
   end
 
   create_table "customers", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -47,8 +47,8 @@ ActiveRecord::Schema.define(version: 2021_05_17_063327) do
     t.integer "system", default: 0
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["address"], name: "index_customers_on_address"
-    t.index ["name"], name: "index_customers_on_name"
+    t.index ["address"], name: "index_customers_on_address", unique: true
+    t.index ["name"], name: "index_customers_on_name", unique: true
   end
 
   create_table "key_people", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -57,7 +57,7 @@ ActiveRecord::Schema.define(version: 2021_05_17_063327) do
     t.text "note"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["name"], name: "index_key_people_on_name"
+    t.index ["name"], name: "index_key_people_on_name", unique: true
   end
 
   create_table "sales_ends", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2021_05_17_063327) do
     t.integer "activity_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["visit_record_id", "activity_id"], name: "index_activity_details_on_visit_record_id_and_activity_id", unique: true
   end
 
   create_table "belongs", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -83,13 +83,9 @@ ActiveRecord::Schema.define(version: 2021_05_17_063327) do
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
-    t.string "reset_password_token"
-    t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["email"], name: "index_users_on_email", unique: true
-    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
   create_table "visit_records", force: :cascade do |t|


### PR DESCRIPTION
### viewsの編集と全般
- 日付表示のカスタムメソッドをnil対応
- タスクの状態メソッドを作成
- フォームにラベルを追加
- btnカラーの統一(以下、Bootstrapのcolor部分)
  - 登録：success
  - 変更：primary
- tasksをvisit_recordの削除に紐付け

### テーブルの整理
- deviseで使用しないカラムを削除
- activity_detailsにunique特性を追加し、contorollerの記述を簡略化 #29 
- belongs, sales_ends, key_people, activitiesのnameカラムにunique特性を追加
- customersのnameとaddressカラムにそれぞれunique特性を追加

### map機能
- geocording serviceを利用するための設定 #31
- customerに紐づくvisit_recordsやtasksが存在しない場合のエラー対策