### PR TITLE
update customer map

### DIFF
--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -58,6 +58,7 @@ class CustomersController < ApplicationController
 
   def update
     if @customer.update(params_customer)
+      @map_status = @customer.saved_change_to_attribute?(:address) ? "change" : "stay"
       render "update"
     else
       @key_people = KeyPerson.all

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -7,7 +7,7 @@ class Customer < ApplicationRecord
   has_many :visit_records
 
   geocoded_by :address
-  before_validation :geocode
+  before_validation :geocode, if: :address_changed?
 
   enum system: {
     systemA: 0,

--- a/app/views/customers/_map.html.slim
+++ b/app/views/customers/_map.html.slim
@@ -1,0 +1,26 @@
+#map.mx-auto.my-4 style='height: 350px;'
+
+script [
+  async='async'
+  src="https://maps.googleapis.com/maps/api/js?key=#{ ENV['GOOGLE_MAP_API'] }&callback=initMap"
+]
+
+javascript:
+  function initMap() {};
+  function initMap() {
+
+		pos = new google.maps.LatLng(
+			#{customer.latitude},
+			#{customer.longitude}
+		);
+
+    var map = new google.maps.Map(document.getElementById('map'), {
+      center: pos,
+      zoom: 15,
+    });
+
+    marker = new google.maps.Marker({
+      position: pos,
+      map: map
+    });
+  }

--- a/app/views/customers/_show.html.slim
+++ b/app/views/customers/_show.html.slim
@@ -1,48 +1,19 @@
-.card.shadow-lg.set_show
-  .card-body
-  	.row
-  		.col-md
-  		  h5.card-title 顧客名
-  		  p.card-text = customer.name
+h5.card-title 顧客名
+p.card-text = customer.name
 
-  		  h5.catd-title 住所
-  		  p.card-text = customer.address
+h5.catd-title 住所
+p.card-text = customer.address
 
-  		  h5.card-title 窓口担当者
-  		  p.card-text = link_to customer.key_person.name, key_person_path(customer.key_person.id)
+h5.card-title 窓口担当者
+p.card-text = link_to customer.key_person.name, key_person_path(customer.key_person.id)
 
-  		  h5.card-title 営業担当者所属
-  		  p.card-text = link_to customer.sales_end.belong.name, belong_path(customer.sales_end.belong.id)
+h5.card-title 営業担当者所属
+p.card-text = link_to customer.sales_end.belong.name, belong_path(customer.sales_end.belong.id)
 
-  		  h5.card-title 営業担当者
-  		  p.card-text = link_to customer.sales_end.name, sales_end_path(customer.sales_end.id)
+h5.card-title 営業担当者
+p.card-text = link_to customer.sales_end.name, sales_end_path(customer.sales_end.id)
 
-  		  h5.card-title 導入システム
-  		  p.card-text = customer.system
+h5.card-title 導入システム
+p.card-text = customer.system
 
-  		  = link_to "編集", edit_customer_path(customer.id), remote: true, class: "btn btn-primary"
-
-  		.col-md
-  		  #map.mx-auto.my-4 style='height: 350px;'
-
-javascript:
-	let map;
-
-  function initMap() {
-    geocoder = new google.maps.Geocoder()
-
-		pos = new google.maps.LatLng(
-			#{customer.latitude},
-			#{customer.longitude}
-		);
-
-    map = new google.maps.Map(document.getElementById('map'), {
-      center: pos,
-      zoom: 15,
-    });
-
-    marker = new google.maps.Marker({
-      position: pos,
-      map: map
-    });
-  }
+= link_to "編集", edit_customer_path(customer.id), remote: true, class: "btn btn-primary"

--- a/app/views/customers/show.html.slim
+++ b/app/views/customers/show.html.slim
@@ -5,4 +5,10 @@
 	h2.customer_name_title #{@customer.name}詳細
 	.row
 		.col
-			= render "customers/show", customer: @customer
+			.card.shadow-lg
+			  .card-body
+			  	.row
+			  		.col-md.set_show
+			  			= render "customers/show", customer: @customer
+			  		.col-md.set_map
+			  			= render "customers/map", customer: @customer

--- a/app/views/customers/update.js.slim
+++ b/app/views/customers/update.js.slim
@@ -1,6 +1,10 @@
-| $('.customer_name_title').html("#{@customer.name}氏詳細");
-| $('.card.shadow-lg').html('');
+| $('.customer_name_title').html("#{@customer.name}詳細");
+| $('.set_show').html('');
 | $(".set_show").html(
 |    "#{j(render 'customers/show', customer: @customer)}"
 | );
+- if @map_status == "change"
+  | $(".set_map").html(
+  |    "#{j(render 'customers/map', customer: @customer)}"
+  | );
 | $("#customer_edit-modal").modal('hide');

--- a/app/views/homes/map.html.erb
+++ b/app/views/homes/map.html.erb
@@ -98,3 +98,5 @@
     });
   }
 </script>
+
+<script src="https://maps.googleapis.com/maps/api/js?key=<%= ENV['GOOGLE_MAP_API'] %>&callback=initMap" async defer></script>

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -12,5 +12,3 @@ html
     = render "layouts/header"
     p#notice = notice
     = yield
-    - google_api = "https://maps.googleapis.com/maps/api/js?key=#{ ENV['GOOGLE_MAP_API'] }&callback=initMap".html_safe
-    script{ async src=google_api }


### PR DESCRIPTION
### mapが表示されないエラーの解決 した。#45
- apiの使用量を抑えるため、address変更時のみgeocodingが発火するように変更
- 同じく、パーシャルをmapとshowに分け、address変更時のみマップを書き換えるよう変更
- apiの記述箇所をjavascriptの前に置き、initmap()を挿入することにより、ajax処理後もマップが表示
- 但し、ajax後はapiの記述が二重に発生するため、エラーメッセージが出る
- apiの記述箇所の移動に伴い、homes#mapのapi記述箇所も変更