### PR TITLE
add request 2nd-1

### DIFF
--- a/app/assets/stylesheets/customer_key_people.scss
+++ b/app/assets/stylesheets/customer_key_people.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the customer_key_people controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,7 +19,7 @@ class ApplicationController < ActionController::Base
     if hour.nil? || minute.nil?
       true
     else
-      hour == "00" && minute == "00" ? true : false
+      hour == "00" && minute == "00"
     end
   end
 

--- a/app/controllers/customer_key_people_controller.rb
+++ b/app/controllers/customer_key_people_controller.rb
@@ -1,0 +1,8 @@
+class CustomerKeyPeopleController < ApplicationController
+	def create
+	end
+	def update
+	end
+	def destroy
+	end
+end

--- a/app/controllers/customer_key_people_controller.rb
+++ b/app/controllers/customer_key_people_controller.rb
@@ -1,8 +1,121 @@
 class CustomerKeyPeopleController < ApplicationController
-	def create
-	end
-	def update
-	end
-	def destroy
-	end
+  before_action :set_customer_key_person, only: [:edit, :update, :destroy]
+
+  def new
+    @customer = Customer.find(params[:customer_id])
+    @customer_key_person = CustomerKeyPerson.new
+    @key_people = current_user.key_people
+    @men_checked = true # ラジオボタンの初期選択は男性
+  end
+
+  def create
+    @customer_key_person = current_user.customer_key_people.new(params_customer_key_person)
+    errors_message = [] # エラーメッセージ用配列
+    @key_person_select = params[:customer_key_person][:key_person_select] # 窓口担当者新規登録or選択のフラグ
+
+    @customer_key_person.transaction do
+      # 窓口担当者新規登録
+      if @key_person_select == "key_person_new"
+        key_person = current_user.key_people.new(params_key_person_new)
+
+        unless key_person.save
+          @key_person_name = key_person.name
+          @key_person_post = key_person.post
+          @key_person_email = key_person.email
+          @key_person_note = key_person.note
+          key_person.sex == "男性" ? @men_checked = true : @female_checked = true
+          errors_message << key_person.errors.full_messages
+        end
+
+        @customer_key_person.key_person_id = key_person.id
+      end
+
+      @customer_key_person.save!
+    end
+    render "create"
+
+	  rescue => e
+	    # トランザクション処理で評価されない場合があるため(エラーメッセージ用)
+	    @customer_key_person.save
+
+	    errors_message << if @key_person_select == "key_person_new"
+	                        @customer_key_person.errors.full_messages_for(:end_period)
+	                      else
+	                        @customer_key_person.errors.full_messages
+	    end
+
+	    flash.now[:alert] = errors_message.join('<br/>').html_safe
+	    @men_checked = true if @key_person_select == "key_person_selection"
+
+	    @customer = @customer_key_person.customer
+	    @key_people = current_user.key_people
+	    render "new"
+  end
+
+  def edit
+  end
+
+  def update
+    # date_selectオブジェクトの返す値が細切れであり、扱いやすい形式に変換するため定義
+    dammy = CustomerKeyPerson.new(params_customer_key_person)
+
+    if dammy.end_period.nil?
+      @customer_key_person.update(params_customer_key_person)
+      render "update"
+    else
+      # 担当期間が終了していない担当者が2人以上存在する場合に変更可能
+      # →現役担当者が1人以上いる状態を保持
+      if @customer_key_person.check_action_ok?
+        if @customer_key_person.update(params_customer_key_person)
+          render "update"
+        else
+          binding.pry
+          flash.now[:alert] = @customer_key_person.errors.full_messages.join
+          render "edit"
+        end
+      else
+        flash.now[:alert] = "他の現役担当者がいる場合、担当期間(終了)の更新が出来ます"
+        render "edit"
+      end
+    end
+  end
+
+  def destroy
+    if @customer_key_person.end_period.nil?
+      if @customer_key_person.check_action_ok?
+        @customer_key_person.destroy
+        render "destroy"
+      else
+        render js: "alert('他の現役担当者がいる場合削除可能です');"
+      end
+    else
+      @customer_key_person.destroy
+      render "destroy"
+    end
+  end
+
+  private
+
+  def set_customer_key_person
+    @customer_key_person = CustomerKeyPerson.find(params[:id])
+  end
+
+  def params_customer_key_person
+    params.require(:customer_key_person).permit(
+      :customer_id,
+      :key_person_id,
+      :start_period,
+      :end_period,
+    )
+  end
+
+  def params_key_person_new
+    params.require(:customer_key_person).permit(
+      :name,
+      :post,
+      :email,
+      :sex,
+      :note,
+    )
+  end
 end

--- a/app/controllers/key_people_controller.rb
+++ b/app/controllers/key_people_controller.rb
@@ -53,6 +53,6 @@ class KeyPeopleController < ApplicationController
   end
 
   def params_key_person
-    params.require(:key_person).permit(:name, :career, :note)
+    params.require(:key_person).permit(:name, :post, :email, :sex, :note)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -12,6 +12,10 @@ module ApplicationHelper
     datetime.nil? ? "なし" : datetime.strftime("%Y-%m-%d %H:%M")
   end
 
+  def def_date(date)
+    date.nil? ? "" : date.strftime("%Y年%m月")
+  end
+
   # simple_formatメソッドではpタグが入って来て扱いにくいため定義した
   def def_format(text)
     text.nil? ? "なし" : safe_join(text.split(/\R/), tag(:br))

--- a/app/helpers/customer_key_people_helper.rb
+++ b/app/helpers/customer_key_people_helper.rb
@@ -1,0 +1,2 @@
+module CustomerKeyPeopleHelper
+end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -5,6 +5,7 @@ class Customer < ApplicationRecord
   belongs_to :sales_end
   belongs_to :key_person
   has_many :visit_records
+  has_many :customer_key_people
   belongs_to :user
 
   geocoded_by :address

--- a/app/models/customer_key_person.rb
+++ b/app/models/customer_key_person.rb
@@ -1,0 +1,5 @@
+class CustomerKeyPerson < ApplicationRecord
+  belong_to :customer
+  belong_to :key_person
+  belong_to :user
+end

--- a/app/models/customer_key_person.rb
+++ b/app/models/customer_key_person.rb
@@ -1,5 +1,21 @@
 class CustomerKeyPerson < ApplicationRecord
-  belong_to :customer
-  belong_to :key_person
-  belong_to :user
+  belongs_to :customer
+  belongs_to :key_person
+  belongs_to :user
+
+  validate :start_end_check
+
+  def start_end_check
+    unless start_period.nil? || end_period.nil?
+      errors.add(:end_period, "が過去日です") unless start_period < end_period
+    end
+  end
+
+  def end_period_array
+    customer.customer_key_people.pluck(:end_period)
+  end
+
+  def check_action_ok?
+    end_period_array.count(nil) > 1
+  end
 end

--- a/app/models/key_person.rb
+++ b/app/models/key_person.rb
@@ -1,7 +1,7 @@
 class KeyPerson < ApplicationRecord
   validates :name, presence: true
   validates :name, uniqueness: { scope: :user_id }
-  validates :email, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
+  validates :email, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i, allow_blank: true }
 
   has_one :customer
   has_many :visit_records

--- a/app/models/key_person.rb
+++ b/app/models/key_person.rb
@@ -5,6 +5,7 @@ class KeyPerson < ApplicationRecord
 
   has_one :customer
   has_many :visit_records
+  has_many :customer_key_people
   belongs_to :user
 
   enum sex: {

--- a/app/models/key_person.rb
+++ b/app/models/key_person.rb
@@ -1,8 +1,14 @@
 class KeyPerson < ApplicationRecord
   validates :name, presence: true
   validates :name, uniqueness: { scope: :user_id }
+  validates :email, format: { with: /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i }
 
   has_one :customer
   has_many :visit_records
   belongs_to :user
+
+  enum sex: {
+    男性: 0,
+    女性: 1,
+  }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,5 @@ class User < ApplicationRecord
   has_many :visit_records
   has_many :activity_details
   has_many :tasks
+  has_many :customer_key_people
 end

--- a/app/views/customer_key_people/_edit.html.slim
+++ b/app/views/customer_key_people/_edit.html.slim
@@ -1,0 +1,36 @@
+.modal-dialog.modal-dialog-centered
+	.modal-content
+		.modal-header
+			h4.modal-title 担当期間の編集
+			button.close [type="button" data-dismiss="modal" aria-label="Close"]
+				span [aria-hidden="true"] &times;
+
+		.modal-body
+			= flash.now[:alert]
+
+			= form_with model: [@customer_key_person.customer, @customer_key_person], remote: true do |f|
+				= f.hidden_field :customer_id, value: @customer_key_person.customer_id
+				= f.hidden_field :key_person_id, value: @customer_key_person.key_person_id
+
+				.form-group
+					.form-inline
+						= f.date_select :start_period,
+							{prompt: true,
+							discard_day: true,
+							start_year: Time.now.year - 20,
+							end_year: Time.now.year},
+							class: "form-control start_period"
+
+						span ~
+
+						= f.date_select :end_period,
+							{prompt: true,
+							discard_day: true,
+							start_year: Time.now.year - 20,
+							end_year: Time.now.year},
+							class: "form-control start_period"
+
+				.modal-footer
+					button.btn.btn-secondary [type="button" data-dismiss="modal"]
+						| 閉じる
+					= f.submit "更新", class: "btn btn-success"

--- a/app/views/customer_key_people/_new.html.slim
+++ b/app/views/customer_key_people/_new.html.slim
@@ -1,0 +1,94 @@
+.modal-dialog.modal-dialog-centered
+	.modal-content
+		.modal-header
+			h4.modal-title 担当期間新規登録
+			button.close [type="button" data-dismiss="modal" aria-label="Close"]
+				span [aria-hidden="true"] &times;
+
+		.modal-body
+			= flash.now[:alert]
+			= form_with model: [@customer, @customer_key_person], remote: true do |f|
+				= f.hidden_field :customer_id, value: @customer.id
+				= f.hidden_field :key_person_select, value: "key_person_selection"
+
+				ul.nav.nav-tabs
+					li.nav-item
+						a.nav-link.active [href="#tab-selection" data-toggle="tab"]
+							| 登録済窓口担当者に紐付け
+					li.nav-item
+						a.nav-link [href="#tab-new" data-toggle="tab"]
+							| 新規窓口担当者に紐付け
+
+				.tab-content.mt-4
+					.tab-pane.active [id="tab-selection"]
+						.form-group
+							= f.label :key_person_id, "窓口担当者"
+							= f.collection_select :key_person_id,
+								@key_people, :id, :name,
+								{prompt: "選択してください"},
+								autofocus: true,
+								class: "form-control key_person_id, js-select2"
+
+					.tab-pane [id="tab-new"]
+						.form-group
+							= f.label :name, "窓口担当者名"
+							= f.text_field :name, value: @key_person_name, autofocus: true, class: "form-control name"
+
+						.form-group
+							= f.label :post, "役職"
+							= f.text_field :post, value: @key_person_post, autofocus: true, class: "form-control post"
+
+						.form-group
+							= f.label :email, "メールアドレス"
+							= f.email_field :email, value: @key_person_email, autofocus: true, class: "form-control email"
+
+						p 性別
+						.form-group
+							.form-check.form-check-inline
+								= f.radio_button :sex, "男性", checked: @men_checked, class: "form-check-input"
+								label.form-check-label 男性
+
+							.form-check.form-check-inline
+								= f.radio_button :sex, "女性", checked: @female_checked, class: "form-check-input"
+								label.form-check-label 女性
+
+						.form-group
+							= f.label :note, "備考"
+							= f.text_area :note, value: @key_person_note, autofocus: true, class: "form-control note"
+
+				.form-group
+					p 担当期間
+					.form-inline
+						= f.date_select :start_period,
+							{prompt: true,
+							discard_day: true,
+							start_year: Time.now.year - 20,
+							end_year: Time.now.year},
+							class: "form-control start_period"
+
+						span ~
+
+						= f.date_select :end_period,
+							{prompt: true,
+							discard_day: true,
+							start_year: Time.now.year - 20,
+							end_year: Time.now.year},
+							class: "form-control start_period"
+
+				.modal-footer
+				  = f.submit "新規登録", class: "btn btn-primary"
+
+/連続render後に発火させる方法がわからなかったため
+javascript:
+	$('.nav-link').on('click', function() {
+  	let target = $(this).attr('href');
+  	let $key_person_select = $('#customer_key_person_key_person_select');
+
+  	if (target == "#tab-new") {
+    	$key_person_select.val("key_person_new");
+  	} else {
+    	$key_person_select.val("key_person_selection");
+  	}
+	});
+
+	setJsSelect2();

--- a/app/views/customer_key_people/_show.html.slim
+++ b/app/views/customer_key_people/_show.html.slim
@@ -1,0 +1,34 @@
+.card.mb-4.shadow-lg
+	h4.card-header 窓口担当者の担当期間管理
+	.card-body
+		table.table.table-hover
+			thead.bg-light
+				tr
+					th 窓口担当者名
+					th 担当期間
+					th
+			tbody
+				- customer.customer_key_people.order('end_period NOT NULL, end_period DESC').each do |customer_key_person|
+					tr class="tr-#{customer_key_person.id}"
+						td = link_to customer_key_person.key_person.name, key_person_path(customer_key_person.key_person_id)
+						td
+							| #{def_date(customer_key_person.start_period)}
+							| ~
+							| #{def_date(customer_key_person.end_period)}
+						td
+							= link_to "編集",
+								edit_customer_customer_key_person_path(customer, customer_key_person),
+								remote: true,
+								class: "btn btn-primary mr-1"
+
+							= link_to "削除",
+								customer_customer_key_person_path(customer, customer_key_person),
+								method: :delete,
+								remote: true,
+								data: {confirm: "削除しますか？"},
+								class: "btn btn-danger"
+
+		= link_to "担当期間を新規登録",
+			new_customer_customer_key_person_path(customer.id, KeyPerson.new),
+			remote: true,
+			class: "btn btn-success"

--- a/app/views/customer_key_people/_tr.html.slim
+++ b/app/views/customer_key_people/_tr.html.slim
@@ -1,0 +1,18 @@
+tr class="tr-#{customer_key_person.id}"
+	td = link_to customer_key_person.key_person.name, key_person_path(customer_key_person.key_person_id)
+	td
+		| #{def_date(customer_key_person.start_period)}
+		| ~
+		| #{def_date(customer_key_person.end_period)}
+	td
+		= link_to "編集",
+			edit_customer_customer_key_person_path(customer_key_person.customer_id, customer_key_person),
+			remote: true,
+			class: "btn btn-primary mr-1"
+
+		= link_to "削除",
+			customer_customer_key_person_path(customer_key_person.customer_id, customer_key_person),
+			method: :delete,
+			remote: true,
+			data: {confirm: "削除しますか？"},
+			class: "btn btn-danger"

--- a/app/views/customer_key_people/create.js.slim
+++ b/app/views/customer_key_people/create.js.slim
@@ -1,0 +1,2 @@
+| $('tbody').append("#{j(render 'customer_key_people/tr',customer_key_person: @customer_key_person)}");
+| $("#customer_edit-modal").modal('hide');

--- a/app/views/customer_key_people/destroy.js.slim
+++ b/app/views/customer_key_people/destroy.js.slim
@@ -1,0 +1,1 @@
+| $('.tr-#{@customer_key_person.id}').remove();

--- a/app/views/customer_key_people/edit.js.slim
+++ b/app/views/customer_key_people/edit.js.slim
@@ -1,0 +1,4 @@
+| $("#customer_edit-modal").html(
+|			"#{j(render 'customer_key_people/edit', customer_key_person: @customer_key_person)}"
+| );
+| $("#customer_edit-modal").modal('show');

--- a/app/views/customer_key_people/new.js.slim
+++ b/app/views/customer_key_people/new.js.slim
@@ -1,0 +1,10 @@
+| $("#customer_edit-modal").html(
+|    "#{j(render 'customer_key_people/new', customer: @customer, customer_key_person: @customer_key_person, key_people: @key_people)}"
+| );
+| $("#customer_edit-modal").modal('show');
+- if flash.now[:alert].present? && @key_person_select == "key_person_new"
+	| $(".nav-link").removeClass('active');
+	| $(".nav-link").last().addClass('active');
+	| $("#tab-selection").removeClass('active');
+	| $("#tab-new").addClass('active');
+	| $('#customer_key_person_key_person_select').val("key_person_new");

--- a/app/views/customer_key_people/update.js.slim
+++ b/app/views/customer_key_people/update.js.slim
@@ -1,0 +1,2 @@
+| $('.tr-#{@customer_key_person.id}').replaceWith("#{j(render 'customer_key_people/tr',customer_key_person: @customer_key_person)}");
+| $("#customer_edit-modal").modal('hide');

--- a/app/views/customers/show.html.slim
+++ b/app/views/customers/show.html.slim
@@ -5,10 +5,14 @@
 h2.customer_name_title #{@customer.name}詳細
 .row
 	.col
-		.card.shadow-lg
+		.card.mb-4.shadow-lg
 		  .card-body
 		  	.row
 		  		.col-md.set_show
 		  			= render "customers/show", customer: @customer
 		  		.col-md.set_map
 		  			= render "customers/map", customer: @customer
+
+.row
+	.col
+		= render "customer_key_people/show", customer: @customer

--- a/app/views/key_people/_form.html.slim
+++ b/app/views/key_people/_form.html.slim
@@ -16,8 +16,22 @@
 		      = f.text_field :name, autofocus: true, class: "form-control name"
 
 		    .form-group
-		      = f.label :career, "経歴"
-		      = f.text_area :career, autofocus: true, class: "form-control career"
+		      = f.label :post, "役職"
+		      = f.text_field :post, autofocus: true, class: "form-control post"
+
+		    .form-group
+		    	= f.label :email, "メールアドレス"
+		    	= f.email_field :email, autofocus: true, class: "form-control email"
+
+		    p 性別
+		    .form-group
+		    	.form-check.form-check-inline
+		    		= f.radio_button :sex, "男性", checked: true, class: "form-check-input"
+		    		label.form-check-label 男性
+
+		    	.form-check.form-check-inline
+		    		= f.radio_button :sex, "女性", class: "form-check-input"
+		    		label.form-check-label 女性
 
 		    .form-group
 		      = f.label :note, "備考"

--- a/app/views/key_people/_show.html.slim
+++ b/app/views/key_people/_show.html.slim
@@ -3,8 +3,14 @@
 		h5.card-title 担当者名
 		p.card-text = key_person.name
 
-		h5.card-title 経歴
-		p.card-text = def_format(key_person.career)
+		h5.card-title 役職
+		p.card-text = key_person.post
+
+		h5.card-title メールアドレス
+		p.card-text = key_person.email
+
+		h5.card-title 性別
+		p.card-text = key_person.sex
 
 		h5.card-title 備考
 		p.card-text = def_format(key_person.note)

--- a/app/views/key_people/create.js.slim
+++ b/app/views/key_people/create.js.slim
@@ -1,6 +1,9 @@
 | $('tbody').prepend("#{j(render 'key_people/tr', key_person: @key_person)}");
 | $('#key_person_name').val("");
-| $('#key_person_career').val("");
+| $('#key_person_post').val("");
+| $('#key_person_email').val("");
+| document.getElementById('key_person_sex_男性').checked = true;
 | $('#key_person_note').val("");
+| $('#key_person_name').focus();
 | $('.error_explanation').empty();
 | $('.js-message-errors').empty();

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -5,6 +5,7 @@ ja:
       activity_detail: 活動内容
       belong: 所属
       customer: 顧客
+      customer_key_person: 窓口担当者管理
       key_person: 窓口担当者
       sales_end: 営業担当者
       task: タスク
@@ -27,6 +28,10 @@ ja:
           name: 顧客名
           key_person: 窓口担当者
           sales_end: 営業担当者
+
+        customer_key_person:
+          key_person: 窓口担当者
+          end_period: 担当期間(終了)
 
         key_person:
           name: 窓口担当者名

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -30,6 +30,7 @@ ja:
 
         key_person:
           name: 窓口担当者名
+          email: メールアドレス
 
         sales_end:
           name: 営業担当者名

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
   resources :activities, only: [:create, :index, :edit, :update]
   post 'activities/search'
   resources :customers, only: [:new, :create, :index, :show, :edit, :update] do
-    resources :customer_key_people, only: [:create, :update, :destroy]
+    resources :customer_key_people, only: [:new, :create, :edit, :update, :destroy]
   end
   post 'customers/search'
   resources :key_people, only: [:create, :index, :show, :edit, :update]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,9 @@ Rails.application.routes.draw do
   get '/tasks' => 'tasks#index'
   resources :activities, only: [:create, :index, :edit, :update]
   post 'activities/search'
-  resources :customers, only: [:new, :create, :index, :show, :edit, :update]
+  resources :customers, only: [:new, :create, :index, :show, :edit, :update] do
+    resources :customer_key_people, only: [:create, :update, :destroy]
+  end
   post 'customers/search'
   resources :key_people, only: [:create, :index, :show, :edit, :update]
   post 'key_people/search'

--- a/db/migrate/20210611125133_change_key_people_column.rb
+++ b/db/migrate/20210611125133_change_key_people_column.rb
@@ -1,0 +1,8 @@
+class ChangeKeyPeopleColumn < ActiveRecord::Migration[5.2]
+  def change
+    add_column :key_people, :post, :string
+    add_column :key_people, :email, :string
+    add_column :key_people, :sex, :intger, default: 0
+    remove_column :key_people, :career, :text
+  end
+end

--- a/db/migrate/20210611161122_create_customer_key_people.rb
+++ b/db/migrate/20210611161122_create_customer_key_people.rb
@@ -1,0 +1,16 @@
+class CreateCustomerKeyPeople < ActiveRecord::Migration[5.2]
+  def change
+    create_table :customer_key_people do |t|
+      t.integer :customer_id
+      t.integer :key_person_id
+      t.date :start_period
+      t.date :end_period
+      t.integer :user_id
+
+      t.timestamps
+    end
+    change_column_null :customer_key_people, :customer_id, false
+    change_column_null :customer_key_people, :key_person_id, false
+    add_index :customer_key_people, :customer_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_27_111513) do
+ActiveRecord::Schema.define(version: 2021_06_11_125133) do
 
   create_table "activities", force: :cascade do |t|
     t.string "name", null: false
@@ -57,11 +57,13 @@ ActiveRecord::Schema.define(version: 2021_05_27_111513) do
 
   create_table "key_people", force: :cascade do |t|
     t.string "name", null: false
-    t.text "career"
     t.text "note"
     t.integer "user_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "post"
+    t.string "email"
+    t.integer "sex", default: 0
     t.index ["name", "user_id"], name: "index_key_people_on_name_and_user_id", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_11_125133) do
+ActiveRecord::Schema.define(version: 2021_06_11_161122) do
 
   create_table "activities", force: :cascade do |t|
     t.string "name", null: false
@@ -38,6 +38,17 @@ ActiveRecord::Schema.define(version: 2021_06_11_125133) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["name", "user_id"], name: "index_belongs_on_name_and_user_id", unique: true
+  end
+
+  create_table "customer_key_people", force: :cascade do |t|
+    t.integer "customer_id", null: false
+    t.integer "key_person_id", null: false
+    t.date "start_period"
+    t.date "end_period"
+    t.integer "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["customer_id"], name: "index_customer_key_people_on_customer_id"
   end
 
   create_table "customers", force: :cascade do |t|

--- a/spec/factories/key_people.rb
+++ b/spec/factories/key_people.rb
@@ -1,7 +1,9 @@
 FactoryBot.define do
   factory :key_person do
     name { Faker::Name.name }
-    career { Faker::Lorem.characters(number: 10) }
+    post { Faker::Lorem.characters(number: 10) }
+    email { Faker::Internet.email }
+    sex { "女性" }
     note { Faker::Lorem.characters(number: 50) }
     user
   end

--- a/spec/models/key_person_spec.rb
+++ b/spec/models/key_person_spec.rb
@@ -30,15 +30,19 @@ RSpec.describe 'KeyPersonモデルのテスト', type: :model do
     before do
       key_person.save
       @key_person_old_name = key_person.name
-      @key_person_old_career = key_person.career
+      @key_person_old_post = key_person.post
+      @key_person_old_email = key_person.email
       @key_person_old_note = key_person.note
 
       @key_person_new_name = Faker::Name.name
-      @key_person_new_career = Faker::Lorem.characters(number: 10)
+      @key_person_new_post = Faker::Lorem.characters(number: 10)
+      @key_person_new_email = Faker::Internet.email
       @key_person_new_note = Faker::Lorem.characters(number: 50)
 
       key_person.name = @key_person_new_name
-      key_person.career = @key_person_new_career
+      key_person.post = @key_person_new_post
+      key_person.email = @key_person_new_email
+      key_person.sex = "男性" # factorybotでは"女性"を選択中
       key_person.note = @key_person_new_note
       key_person.save
     end
@@ -48,9 +52,19 @@ RSpec.describe 'KeyPersonモデルのテスト', type: :model do
       expect(key_person.name).to eq @key_person_new_name
     end
 
-    it 'careerカラムが更新できる' do
-      expect(key_person.career).not_to eq @key_person_old_career
-      expect(key_person.career).to eq @key_person_new_career
+    it 'postカラムが更新できる' do
+      expect(key_person.post).not_to eq @key_person_old_post
+      expect(key_person.post).to eq @key_person_new_post
+    end
+
+    it 'emailカラムが更新できる' do
+      expect(key_person.email).not_to eq @key_person_old_email
+      expect(key_person.email).to eq @key_person_new_email
+    end
+
+    it 'sexカラムが更新できる' do
+      expect(key_person.sex).not_to eq "女性"
+      expect(key_person.sex).to eq "男性"
     end
 
     it 'noteカラムが更新できる' do

--- a/spec/system/key_person_spec.rb
+++ b/spec/system/key_person_spec.rb
@@ -40,8 +40,17 @@ describe '窓口担当者画面' do
         is_expected.to have_field '窓口担当者名'
       end
 
-      it '経歴フォームが表示される' do
-        is_expected.to have_field '経歴'
+      it '役職フォームが表示される' do
+        is_expected.to have_field '役職'
+      end
+
+      it 'メールアドレスフォームが表示される' do
+        is_expected.to have_field 'メールアドレス'
+      end
+
+      it '性別フォームが表示される' do
+        is_expected.to have_checked_field 'key_person_sex_男性'
+        is_expected.not_to have_checked_field 'key_person_sex_女性'
       end
 
       it '備考フォームが表示される' do

--- a/test/controllers/customer_key_people_controller_test.rb
+++ b/test/controllers/customer_key_people_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CustomerKeyPeopleControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/customer_key_people.yml
+++ b/test/fixtures/customer_key_people.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  customer_id: 1
+  key_person_id: 1
+
+two:
+  customer_id: 1
+  key_person_id: 1

--- a/test/models/customer_key_person_test.rb
+++ b/test/models/customer_key_person_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CustomerKeyPersonTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
### 窓口担当者のテーブルのカラムを変更 #81
- 追加
  - 役職
  - メールアドレス
  - 性別
- 削除
 - 経歴（窓口担当者の担当期間管理追加のため） 

### 顧客に紐づく窓口担当者の担当期間管理機能を実装 #81
1. CustomerKeyPersonのMVCモデルを作成
2. customers#showに世代管理テーブルと担当者担当期間管理の新規登録・編集機能を追加