### PR TITLE
add request 2nd-2

### DIFF
--- a/app/controllers/customer_key_people_controller.rb
+++ b/app/controllers/customer_key_people_controller.rb
@@ -42,7 +42,7 @@ class CustomerKeyPeopleController < ApplicationController
 	                        @customer_key_person.errors.full_messages_for(:end_period)
 	                      else
 	                        @customer_key_person.errors.full_messages
-	    end
+	                      end
 
 	    flash.now[:alert] = errors_message.join('<br/>').html_safe
 	    @men_checked = true if @key_person_select == "key_person_selection"
@@ -69,7 +69,6 @@ class CustomerKeyPeopleController < ApplicationController
         if @customer_key_person.update(params_customer_key_person)
           render "update"
         else
-          binding.pry
           flash.now[:alert] = @customer_key_person.errors.full_messages.join
           render "edit"
         end

--- a/app/controllers/customers_controller.rb
+++ b/app/controllers/customers_controller.rb
@@ -12,57 +12,81 @@ class CustomersController < ApplicationController
 
   def create
     @customer = current_user.customers.new(params_customer)
+    radio_key_person = params[:customer][:radio_key_person]
+    radio_sales_end = params[:customer][:radio_sales_end]
+    radio_belong = params[:customer][:radio_belong]
 
     @customer.transaction do
       # 窓口担当者で新規登録を選択
-      if params_key_person[:radio_key_person] == "new"
+      if radio_key_person == "new"
         @radio_key_person_select = ""
         @radio_key_person_new = "checked"
-        @key_person_new_value = params_key_person[:key_person_name]
+        @key_person_new_value = params[:customer][:key_person_name]
+
         key_person = current_user.key_people.create(name: @key_person_new_value)
+        flash.now[:alert_key_person] = key_person.errors.full_messages_for(:name).join
         @customer.key_person_id = key_person.id
       end
 
       # 営業担当者で新規登録を選択
-      if params_sales_end[:radio_sales_end] == "new"
+      if radio_sales_end == "new"
         @radio_sales_end_select = ""
         @radio_sales_end_new = "checked"
-        @sales_end_new_value = params_sales_end[:sales_end_name]
+        @sales_end_new_value = params[:customer][:sales_end_name]
+
         sales_end = current_user.sales_ends.new(name: @sales_end_new_value)
 
         # 所属で登録済を選択
-        if params_belong[:radio_belong] == "select"
-          if params_belong[:belong_id].empty?
-            flash.now[:alert_belong] = "所属を選択下さい"
-          else
-            @selected_belong = params_belong[:belong_id]
-            sales_end.belong_id = @selected_belong
-          end
+        if radio_belong == "select"
+          @selected_belong = params[:customer][:belong_id]
+
+          sales_end.belong_id = @selected_belong
+
         # 所属で新規登録を選択
         else
           @radio_belong_select = ""
           @radio_belong_new = "checked"
-          if params_belong[:belong_name].blank?
-            flash.now[:alert_belong] = "所属を入力下さい"
-          else
-            @belong_new_value = params_belong[:belong_name]
-            belong = current_user.belongs.create(name: @belong_new_value)
-            sales_end.belong_id = belong.id
-          end
+          @belong_new_value = params[:customer][:belong_name]
+
+          belong = current_user.belongs.create(name: @belong_new_value)
+          flash.now[:alert_belong] = belong.errors.full_messages_for(:name).join
+          sales_end.belong_id = belong.id
         end
         sales_end.save
+        flash.now[:alert_sales_end] = sales_end.errors.full_messages_for(:name).join
+        if radio_belong == "select"
+          flash.now[:alert_belong] =
+            sales_end.errors.full_messages_for(:belong).join
+        end
         @customer.sales_end_id = sales_end.id
       end
       @customer.save!
     end
+
+    # 窓口担当者の担当期間管理に新規登録
+    current_user.customer_key_people.create(
+      customer_id: @customer.id,
+      key_person_id: @customer.key_person_id
+    )
     redirect_to customer_path(@customer.id)
 
-    rescue => e
-      @key_people = current_user.key_people
-      @sales_ends = current_user.sales_ends
-      @belongs = current_user.belongs
-      gon.radio_sales_end_select = @radio_sales_end_select
-      render "new"
+  rescue => e
+    flash.now[:alert_name] = @customer.errors.full_messages_for(:name).join
+    if radio_key_person == "select"
+      flash.now[:alert_key_person] =
+        @customer.errors.full_messages_for(:key_person).join
+    end
+    if radio_sales_end == "select"
+      flash.now[:alert_sales_end] =
+        @customer.errors.full_messages_for(:sales_end).join
+    end
+
+    @key_people = current_user.key_people
+    @sales_ends = current_user.sales_ends
+    @belongs = current_user.belongs
+    gon.radio_sales_end_select = @radio_sales_end_select
+
+    render "new"
   end
 
   def index
@@ -75,7 +99,7 @@ class CustomersController < ApplicationController
   end
 
   def edit
-    @key_people = current_user.key_people
+    @key_people = KeyPerson.where(id: @customer.customer_key_people.pluck(:key_person_id))
     @sales_ends = current_user.sales_ends
   end
 
@@ -84,7 +108,7 @@ class CustomersController < ApplicationController
       @map_status = @customer.saved_change_to_attribute?(:address) ? "change" : "stay"
       render "update"
     else
-      @key_people = current_user.key_people
+      @key_people = KeyPerson.where(id: @customer.customer_key_people.pluck(:key_person_id))
       @sales_ends = current_user.sales_ends
       render "edit"
     end
@@ -132,28 +156,6 @@ class CustomersController < ApplicationController
       :longitude,
       :system,
       :note,
-    )
-  end
-
-  def params_key_person
-    params.require(:customer).permit(
-      :radio_key_person,
-      :key_person_name,
-    )
-  end
-
-  def params_sales_end
-    params.require(:customer).permit(
-      :radio_sales_end,
-      :sales_end_name,
-    )
-  end
-
-  def params_belong
-    params.require(:customer).permit(
-      :radio_belong,
-      :belong_id,
-      :belong_name,
     )
   end
 end

--- a/app/views/customers/_edit.html.slim
+++ b/app/views/customers/_edit.html.slim
@@ -24,6 +24,8 @@
 		      	{prompt: "選択して下さい"},
 		      	autofocus: true,
 		      	class: "form-control key_person_id js-select2"
+		      p.small
+		      	| ※担当期間管理で管理されている窓口担当者のリストです
 
 		    .form-group
 		      = f.label :sales_end_id, "営業担当者"
@@ -43,3 +45,6 @@
 
 		    .modal-footer
 		      = f.submit "変更保存", class: "btn btn-primary"
+
+javascript:
+	setJsSelect2();

--- a/app/views/customers/edit.js.slim
+++ b/app/views/customers/edit.js.slim
@@ -1,4 +1,4 @@
 | $("#customer_edit-modal").html(
-|    "#{j(render 'customers/form_edit', customer: @customer, key_people: @key_people, sales_ends: @sales_ends)}"
+|    "#{j(render 'customers/edit', customer: @customer, key_people: @key_people, sales_ends: @sales_ends)}"
 | );
 | $("#customer_edit-modal").modal('show');

--- a/app/views/customers/new.html.slim
+++ b/app/views/customers/new.html.slim
@@ -4,17 +4,26 @@
 h2 顧客新規登録
 .row
 	.col-md-8
-	  = render "shared/error", obj: @customer
 	  = form_with model: @customer, local: true do |f|
 	    .form-group
-	      = f.label :name, "顧客名"
+	      p
+	        | 顧客名
+	        span.badge.badge-danger.ml-1 必須
+	      - if flash[:alert_name].present?
+	        p.text-danger = flash[:alert_name]
+
 	      = f.text_field :name, autofocus: true, class: "form-control name"
 
 	    .form-group
 	      = f.label :address, "住所"
 	      = f.text_field :address, autofocus: true, class: "form-control address"
 
-	    p 窓口担当者
+	    p
+	      | 窓口担当者
+	      span.badge.badge-danger.ml-1 必須
+	    - if flash[:alert_key_person].present?
+	       p.text-danger = flash[:alert_key_person]
+
 	    .form-group.row
 	      .form-group.col
 	      	.form-check
@@ -31,8 +40,15 @@ h2 顧客新規登録
 	        	= f.radio_button :radio_key_person, :new, checked: @radio_key_person_new, class: "form-check-input"
 	        	label.form-check-label 新規登録
 	        = f.text_field :key_person_name, value: @key_person_new_value, class: "form-control key_person_name"
+	        p.small
+	          | ※詳細は顧客の新規登録後に個別で編集下さい
 
-	    p 営業担当者
+	    p
+	      | 営業担当者
+	      span.badge.badge-danger.ml-1 必須
+	    - if flash[:alert_sales_end].present?
+	      p.text-danger = flash[:alert_sales_end]
+
 	    .form-group.row
 	      .form-group.col
 	      	.form-check
@@ -49,11 +65,15 @@ h2 顧客新規登録
 	        	= f.radio_button :radio_sales_end, :new, checked: @radio_sales_end_new, class: "form-check-input"
 	        	label.form-check-label 新規登録
 	        = f.text_field :sales_end_name, value: @sales_end_new_value, class: "form-control sales_end_name"
+	        p.small
+	          | ※詳細は顧客の新規登録後に個別で編集下さい
 
 	    /営業担当者で"新規登録"を選択した場合表示
 	    #selected_sales_end_new
-	      p 所属 (営業担当者で"新規登録"を選択した場合入力下さい)
-	      - unless flash[:alert_belong].nil?
+	      p
+	        | 所属 (営業担当者で"新規登録"を選択した場合入力下さい)
+	        span.badge.badge-danger.ml-1 必須
+	      - if flash[:alert_belong].present?
 	        p.text-danger = flash[:alert_belong]
 
 	      .form-group.row
@@ -73,6 +93,8 @@ h2 顧客新規登録
 	        		= f.radio_button :radio_belong, :new, checked: @radio_belong_new, class: "form-check-input"
 	        		label.form-check-label 新規登録
 	        	= f.text_field :belong_name, value: @belong_new_value,class: "form-control belong_name"
+	        	p.small
+	        	  | ※詳細は顧客の新規登録後に個別で編集下さい
 
 	    .form-group
 	      = f.label :system, "導入システム"

--- a/spec/system/customer_spec.rb
+++ b/spec/system/customer_spec.rb
@@ -175,7 +175,7 @@ describe '顧客画面' do
       end
 
       it '顧客名フォームが表示される' do
-        is_expected.to have_field '顧客名'
+        is_expected.to have_field 'customer[name]'
       end
 
       it '住所フォームが表示される' do


### PR DESCRIPTION
### 顧客に紐づく窓口担当者の担当期間管理機能を実装 #81
3. customers#newと#editのviewsとcontrollerを編集
- 顧客の新規登録で窓口担当者の担当期間管理に新規登録
- 顧客の編集で窓口担当者の選択一覧を、担当期間管理で管理する窓口担当者に変更

### customersコントローラーのリファクタリング
### エラーメッセージの修正 #56
- 対応する箇所にエラー内容が表示されるよう修正
- 記入の必要箇所を明確化