### PR TITLE
update customer_key_people#update

### DIFF
--- a/app/controllers/customer_key_people_controller.rb
+++ b/app/controllers/customer_key_people_controller.rb
@@ -56,26 +56,11 @@ class CustomerKeyPeopleController < ApplicationController
   end
 
   def update
-    # date_selectオブジェクトの返す値が細切れであり、扱いやすい形式に変換するため定義
-    dammy = CustomerKeyPerson.new(params_customer_key_person)
-
-    if dammy.end_period.nil?
-      @customer_key_person.update(params_customer_key_person)
+    if @customer_key_person.update(params_customer_key_person)
       render "update"
     else
-      # 担当期間が終了していない担当者が2人以上存在する場合に変更可能
-      # →現役担当者が1人以上いる状態を保持
-      if @customer_key_person.check_action_ok?
-        if @customer_key_person.update(params_customer_key_person)
-          render "update"
-        else
-          flash.now[:alert] = @customer_key_person.errors.full_messages.join
-          render "edit"
-        end
-      else
-        flash.now[:alert] = "他の現役担当者がいる場合、担当期間(終了)の更新が出来ます"
-        render "edit"
-      end
+      flash.now[:alert] = @customer_key_person.errors.full_messages.join('<br/>').html_safe
+      render "edit"
     end
   end
 

--- a/app/models/customer_key_person.rb
+++ b/app/models/customer_key_person.rb
@@ -4,10 +4,19 @@ class CustomerKeyPerson < ApplicationRecord
   belongs_to :user
 
   validate :start_end_check
+  validate :end_period_check, on: :update
 
   def start_end_check
     unless start_period.nil? || end_period.nil?
       errors.add(:end_period, "が過去日です") unless start_period < end_period
+    end
+  end
+
+  def end_period_check
+    if will_save_change_to_attribute?(:end_period)
+      if attribute_in_database(:end_period).nil?
+        errors.add(:end_period, "は更新できません(他の現役担当者が必要)") unless check_action_ok?
+      end
     end
   end
 


### PR DESCRIPTION
### 担当期間の更新アルゴリズムの修正 #92 
顧客ごとに、担当期間終了カラムが空白である担当者が常に一人以上存在する更新のみを可能とした。